### PR TITLE
Fix list_installed delete for zypper

### DIFF
--- a/src/zypper.sh
+++ b/src/zypper.sh
@@ -15,7 +15,11 @@ _zypper() {
 list_installed() {
     local installed installedInit
     
+<<<<<<< Updated upstream
     mapfile -t installed < <(zypper search -i)
+=======
+    mapfile -t installed < <(zypper search -i | awk '{print $3}')
+>>>>>>> Stashed changes
     installedInit=("${installed[@]}")
     
     printf '\e[2J'


### PR DESCRIPTION
Small change to only show package name when doing list_installed on zypper.

Also fixes delete during list_installed